### PR TITLE
Change to Rust and Node install pages that notices your OS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ This will compile the WebAssembly module and start a local web server. Open your
 
 ### Requirements
 
-* Rust <https://www.rust-lang.org>
+* Install rust <https://www.rust-lang.org/tools/install>
 * `wasm-pack` <https://rustwasm.github.io/wasm-pack/>
 * `wasm32-unknown-unknown`
-* npm <https://www.npmjs.com>
+* Install node <https://nodejs.org/en/> (node comes with npm)
 
 ### Build
 


### PR DESCRIPTION
Npm navigates to node:
https://www.npmjs.com/get-npm

navigates to https://nodejs.org/en/ 

The nodejs install site notices your operating system.

If you do not like the node website consider using this link: https://www.npmjs.com/get-npm

Feel free to close the pull request if you disagree; I was reading through the project and those changes helped me get up and running faster.